### PR TITLE
Update probe gcode to account for the faster Z axis of the 2.4 (and maybe some other printers)

### DIFF
--- a/config/tap_klipper_instructions.md
+++ b/config/tap_klipper_instructions.md
@@ -18,27 +18,31 @@ There are a few changes you'll need to make in order to get Tap working properly
    
    - Remember, with Tap, your nozzle IS the probe, so your `[probe] x_offset` and `[probe] y_offset` values should be 0 now. You'll need to manually calibrate the probe's Z offset by using `PROBE_CALIBRATE`.
    
-4. Add Tap's `activate_gcode:`  
+4. Add Tap's `activate_gcode:` and `deactivate_gcode` 
    
-   - This G-code will allow you to probe cold, but will also prevent you from probing with a nozzle at printing temperature (to try to preserve your build surface). This goes in the `[probe]` section of your config.  
+   - This G-code will allow you to probe cold, but will also prevent you from probing with a nozzle at printing temperature (to try to preserve your build surface), and too fast, particularly on the 2.4, to prevent inaccurate readings, preemptive triggering of the probe, or; in the case of the trident; damaging the tool head due to high Z accelerations. This goes in the `[probe]` section of your config.  
 
 ```jinja
 
 activate_gcode:
-    {% set PROBE_TEMP = 150 %}
-    {% set MAX_TEMP = PROBE_TEMP + 5 %}
-    {% set ACTUAL_TEMP = printer.extruder.temperature %}
-    {% set TARGET_TEMP = printer.extruder.target %}
-
-    {% if TARGET_TEMP > PROBE_TEMP %}
-        { action_respond_info('Extruder temperature target of %.1fC is too high, lowering to %.1fC' % (TARGET_TEMP, PROBE_TEMP)) }
-        M109 S{ PROBE_TEMP }
-    {% else %}
-        # Temperature target is already low enough, but nozzle may still be too hot.
-        {% if ACTUAL_TEMP > MAX_TEMP %}
-            { action_respond_info('Extruder temperature %.1fC is still too high, waiting until below %.1fC' % (ACTUAL_TEMP, MAX_TEMP)) }
-            TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={ MAX_TEMP }
-        {% endif %}
-    {% endif %}
-    
+   {% set PROBE_TEMP = 150 %}
+   {% set MAX_TEMP = PROBE_TEMP + 5 %}
+   {% set ACTUAL_TEMP = printer.extruder.temperature %}
+   {% set TARGET_TEMP = printer.extruder.target %}
+   SET_KINEMATICS_LIMIT Z_ACCEL=20 Z_VELOCITY=30 # may need to be tuned per printer. 
+   {% if TARGET_TEMP > PROBE_TEMP %}
+      { action_respond_info('Extruder temperature target of %.1fC is too high, lowering to %.1fC' % (TARGET_TEMP, PROBE_TEMP)) }
+      M109 S{ PROBE_TEMP }
+   {% else %}
+   # The temperature target is already low enough, but the nozzle may still be too hot.
+      {% if ACTUAL_TEMP > MAX_TEMP %}
+         { action_respond_info('Extruder temperature %.1fC is still too high, waiting until below %.1fC' % (ACTUAL_TEMP, MAX_TEMP)) }
+         TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={ MAX_TEMP }
+      {% endif %}
+   {% endif %}
+on_deactivate_gcode:
+   SET_KINEMATICS_LIMIT Z_ACCEL=<regular_accel> Z_VELOCITY=<regular_velocity>    
 ```
+
+5. turn off `deactivate_on_each_sample`
+   - if left on it will move away from the bed at regular Z-axis speed, which will cause inaccuracies in bed meshing. Add `deactivate_on_each_sample: False` to the probe section of your config. 

--- a/config/tap_klipper_instructions.md
+++ b/config/tap_klipper_instructions.md
@@ -29,7 +29,7 @@ activate_gcode:
    {% set MAX_TEMP = PROBE_TEMP + 5 %}
    {% set ACTUAL_TEMP = printer.extruder.temperature %}
    {% set TARGET_TEMP = printer.extruder.target %}
-   SET_KINEMATICS_LIMIT Z_ACCEL=20 Z_VELOCITY=30 # may need to be tuned per printer. 
+   SET_KINEMATICS_LIMIT Z_ACCEL=15 # may need to be tuned per printer. 
    {% if TARGET_TEMP > PROBE_TEMP %}
       { action_respond_info('Extruder temperature target of %.1fC is too high, lowering to %.1fC' % (TARGET_TEMP, PROBE_TEMP)) }
       M109 S{ PROBE_TEMP }


### PR DESCRIPTION
Keep in mind my tests were on a trident, which, with the steppers Siboor provided, is capable of around 500-800 mm/s^2 on the Z axis without much issue. My 2.4 could hit 1200mm/s^2 on Z. However, I quickly found that a fast Z axis doesn't mix well with TAP, at least whilst probing. So the updated instructions are to account for that.

My test printer for these changes:

* Voron Trident 350 from Siboor
* integrated lead screw steppers for Z (don't have a model number)
* Vatali Metal Tap with 4 magnets
* Danger Klipper bleeding edge V2 (Changes may very likely work on mainline)

Preliminary results:
* accel at 800 mm/s^2 (typically doable for a 2.4)
    - too much force and caused the magnets to come out due to the weak glue I used.
* accel set to 100 and 50 mm/s^2 via new activate and deactivate gcode
    - caused probing results to be inaccurate, particularly with z tilt
* accel and velocity set to default values in cfg snippet
    - worked well enough for z tilt, ~but bed mesh was thrown way out of whack because it would retract at full speed~ EDIT: it was an older bed mesh I was using then. need some tests with KAMP since stock ABM isn't viewable in Mainsail.
* after disabling deactivate on probe
    - seems to help but with me only doing adaptive meshing from klipper I can't view the results. I'll switch over to KAMP's method so I can view it. 

keep in mind that I not too sure if SET_KINEMATICS_LIMIT is in mainline klipper or not, as it's not documented in mainline's docs nor DK's, but I'm fairly certain that setting the z accel and velocity via the cfg is doable in mainline.

Wy is this needed?

well while probing speed affects velocity, it doesn't affect acceleration. The 50mm/s I was using at first, and seems to be the default probing speed for most kits, will be done at 500mm/s^2 or whatever the Z-axis accel is. On the 2.4 it may cause preemptive triggering due to inertia, on the trident, particularly with a belted Z axis mod, it may damage the toolhead.